### PR TITLE
Close tabulation

### DIFF
--- a/R/demography_functions.R
+++ b/R/demography_functions.R
@@ -662,14 +662,14 @@ periodTabulate <- function (age_death,
         start_mat <- start_mat + start_offset
         end_mat <- end_mat + end_offset
 
-        # determine whether the bin was actually observed
-        observed_mat <- (delay_mat - extra_delay_mat) > 0
+        # define truncation for interviews before the end of the period
+        trunc_mat <- start_mat - delay_mat
 
         # add effective number exposed
         exposed_cohort <- (birth_int <= end_mat &  # entered cohort before cohort end date
                              birth_int >= start_mat &  # entered cohort after cohort start date
-                             age_death >= lower_mat &  # alive at start of cohort
-                             observed_mat)  # the period ended before the interview date
+                             age_death >= lower_mat & # alive at start of cohort
+                             birth_int >= trunc_mat)  # interview observed some of this bin
 
         # and effective number that died
         deaths_cohort <- (exposed_cohort > 0 &  # actually exposed this time

--- a/R/demography_functions.R
+++ b/R/demography_functions.R
@@ -663,7 +663,7 @@ periodTabulate <- function (age_death,
         end_mat <- end_mat + end_offset
 
         # determine whether the bin was actually observed
-        observed_mat <- (interview_date - delay_mat - extra_delay_mat) > 0
+        observed_mat <- (delay_mat - extra_delay_mat) > 0
 
         # add effective number exposed
         exposed_cohort <- (birth_int <= end_mat &  # entered cohort before cohort end date

--- a/R/demography_functions.R
+++ b/R/demography_functions.R
@@ -662,10 +662,14 @@ periodTabulate <- function (age_death,
         start_mat <- start_mat + start_offset
         end_mat <- end_mat + end_offset
 
+        # determine whether the bin was actually observed
+        observed_mat <- (interview_date - delay_mat - extra_delay_mat) > 0
+
         # add effective number exposed
         exposed_cohort <- (birth_int <= end_mat &  # entered cohort before cohort end date
                              birth_int >= start_mat &  # entered cohort after cohort start date
-                             age_death >= lower_mat) # alive at start of cohort
+                             age_death >= lower_mat &  # alive at start of cohort
+                             observed_mat)  # the period ended before the interview date
 
         # and effective number that died
         deaths_cohort <- (exposed_cohort > 0 &  # actually exposed this time


### PR DESCRIPTION
There was a bug in `periodTabulate` that counted exposures that hadn't been observed, and assigned them as survivals, despite the outcome not being known. This would inflate survival probabilties.

This bug was due to not explicitly censoring exposures in periods after the interview, combined with the fact that children who hadn't died by the time of the interview are typically recorded as having an age at death of 6000 months (500 years).

This means that a child born in 2008, interviewed (and still alive) in 2009, would count toward the exposures in some months of the final age bin in the 2013-2017. They'd also be recorded as surviving (since the data says they lived to 500).
