### PR TITLE
Stop double counting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: seegMBG
 Type: Package
 Title: Streamlined Model-Based Geostatistics Functions for the SEEG Research
     Group
-Version: 0.1-1
+Version: 0.1-2
 Date: 2015-09-24
 Author: Nick Golding
 Maintainer: Nick Golding <nick.golding.research@gmail.com>

--- a/R/demography_functions.R
+++ b/R/demography_functions.R
@@ -507,21 +507,16 @@ periodTabulate <- function (age_death,
                            windows_upper[w],
                            by = 1)
 
-        # account for the 0th month not being made into a sequence
-        if (length(new_windows) == 1 && new_windows == 0) {
-          new_windows <- c(0, 0)
-        }
-
         # number of new windows
-        n_nw <- length(new_windows) - 1
+        n_nw <- length(new_windows)
 
         # recursively call this function with method = direct, calculating
         # numbers for monthly bins
         res_tmp <- periodTabulate(age_death = age_death,
                                   birth_int = birth_int,
                                   cluster_id = cluster_id,
-                                  windows_lower = new_windows[-n_nw],
-                                  windows_upper = new_windows[-1],
+                                  windows_lower = new_windows,
+                                  windows_upper = new_windows,
                                   nperiod = 1,
                                   period = period,
                                   period_end = period_end,

--- a/R/demography_functions.R
+++ b/R/demography_functions.R
@@ -666,7 +666,7 @@ periodTabulate <- function (age_death,
         trunc_mat <- start_mat - delay_mat
 
         # add effective number exposed
-        exposed_cohort <- (birth_int <= end_mat &  # entered cohort before cohort end date
+        exposed_cohort <- (birth_int < end_mat &  # entered cohort before cohort end date
                              birth_int >= start_mat &  # entered cohort after cohort start date
                              age_death >= lower_mat & # alive at start of cohort
                              birth_int >= trunc_mat)  # interview observed some of this bin


### PR DESCRIPTION
There were two bugs:
- exposures were overestimated very slightly because there was a `>=` and a `<=`
- the windows were incorrectly indexed, messing up the monthly mortality tabulation, increasing the implied mortality rate

This PR fixes both and increments the package version
