### PR TITLE
Fix tapply re-sort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 
 install:
   - sudo apt-get install libgdal1-dev libproj-dev
+  - ./pkg-build.sh install_aptget r-cran-rgdal r-cran-rgeos
   - ./pkg-build.sh install_github SEEG-Oxford/seegSDM andrewzm/INLA
   - ./pkg-build.sh install_deps
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,58 @@
-## Sample .travis.yml file for use with metacran/r-builder
-## See https://github.com/metacran/r-builder for details.
-
-language: c
+language: r
+dist: trusty
+cache: packages
 sudo: required
 
-before_install:
-  - curl -OL https://raw.githubusercontent.com/metacran/r-builder/master/pkg-build.sh
-  - chmod 755 pkg-build.sh
-  - ./pkg-build.sh bootstrap
+##
+# code to get gdal working #
+addons:
+  apt:
+    packages:
+      - libgdal1-dev
+      - libproj-dev
+      
+r_binary_packages:
+ - rgdal
+ - rgeos
+ - raster
+ - mgcv
+ - snowfall
+ - deldir
+ - sp
 
-install:
-  - sudo apt-get install libgdal1-dev libproj-dev
-  - ./pkg-build.sh install_aptget r-cran-rgdal r-cran-rgeos
-  - ./pkg-build.sh install_github SEEG-Oxford/seegSDM andrewzm/INLA
-  - ./pkg-build.sh install_deps
+r_github_packages:
+ - andrewzm/INLA
+ - SEEG-Oxford/seegSDM
 
-script:
-  - ./pkg-build.sh run_tests
+# Install the suggested packages which
+# are needed for the vignette builds
+r_packages:
+ - testthat
+ - covr
 
-after_failure:
-  - ./pkg-build.sh dump_logs
-
+## After success update the code coverage and deploy the pkgdown to gh-pages
+after_success:
+ - Rscript -e 'library(covr);codecov()'
+ 
+# Warnings don't fail build
+warnings_are_errors: false
+ 
+## Email notification if the package pass status changes
 notifications:
-  email:
-    on_success: change
-    on_failure: change
-
+email:
+  on_success: change
+  on_failure: change
+  
+## Set up the matrix of different runs
 env:
   matrix:
-    - RVERSION=oldrel
-      R_CHECK_ARGS="--no-manual"
-    - RVERSION=release
-      R_CHECK_ARGS="--no-manual"
-    - RVERSION=devel
-      R_CHECK_ARGS="--no-manual"
-
+    - r: old_rel
+      not_cran: false
+      r_check_args: "--no-manual --as--cran"
+    - r: release
+      not_cran: false
+      r_check_args: "--no-manual --as--cran"
+    - r: devel
+      not_cran: false
+      r_check_args: "--no-manual --as--cran"
+      

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Package: seegMBG
 Type: Package
 Title: Streamlined Model-Based Geostatistics Functions for the SEEG Research
     Group
-Version: 0.1-2
-Date: 2015-09-24
+Version: 0.1-3
+Date: 2017-03-16
 Author: Nick Golding
 Maintainer: Nick Golding <nick.golding.research@gmail.com>
 Description: A number of utility functions for carrying out model-based

--- a/R/demography_functions.R
+++ b/R/demography_functions.R
@@ -536,6 +536,13 @@ periodTabulate <- function (age_death,
         exposed_mnth <- tapply(res_tmp$exposed, res_tmp$cluster_id, sum)
         died_mnth <- tapply(res_tmp$died, res_tmp$cluster_id, sum)
 
+        # re-order these
+        o_exposed <- match(res_tmp$cluster_id, names(exposed_mnth))
+        exposed_mnth <- exposed_mnth[o_exposed]
+        
+        o_died <- match(res_tmp$cluster_id, names(died_mnth))
+        died_mnth <- died_mnth[o_exposed]
+        
         if (mortality == 'bin') {
 
           # get expected period exposures

--- a/R/transform_functions.R
+++ b/R/transform_functions.R
@@ -58,79 +58,79 @@ pcaTrans <- function(coords, covs) {
 
 #' @name gamTrans
 #' @rdname gamTrans
-#'
+#'   
 #' @title Carry out a model-based covariate transformation using a GAM
-#'
-#' @description Define an optimal set of univariate covariate
-#'  transformations of a set of model covariates by fitting a generalised
-#'  additive model with univariate smoothers to data, and then using the
-#'  smoothers to spline-transform the covariates.
-#'  This makes use of the\code{type = 'terms'} argument in
-#'  \code{\link{predict.gam}}.
-#'  This function also makes use of
-#'
+#'   
+#' @description Define an optimal set of univariate covariate transformations of
+#'   a set of model covariates by fitting a generalised additive model with 
+#'   univariate smoothers to data, and then using the smoothers to 
+#'   spline-transform the covariates. This makes use of the\code{type = 'terms'}
+#'   argument in \code{\link{predict.gam}}. This function also makes use of
+#'   
 #' @param coords a two-column matrix of coordinates of records
-#'
-#' @param response an object acting as thge response object in the GAM
-#'  model (e.g. a vector of counts, or a matrix for binomial data)
-#'
-#' @param covs a \code{Raster*} object giving the spatial covariates
-#'  for the main part of the model
-#'
+#'   
+#' @param response an object acting as thge response object in the GAM model 
+#'   (e.g. a vector of counts, or a matrix for binomial data)
+#'   
+#' @param covs a \code{Raster*} object giving the spatial covariates for the 
+#'   main part of the model
+#'   
 #' @param family the distribution family for the gam
-#'
-#' @param condition an optional vector of 1s and 0s of the same length as
-#'  the number of records in \code{coords} and \code{response} and stating
-#'  whether the record should also be modelled using covariates in
-#'  \code{condition_covs} (1 if so and 0 if not). This enables the construction
-#'  of slightly more complex models, such as those with an explicitly modelled
-#'  observation process. This is achieved by passing \code{condition} to the
-#'  \code{by} argument in \code{mgcv::s} when fitting smooths for
-#'  the condition covariates, as well as adding the condition as an intercept.
-#'
-#' @param condition_covs an optional \code{Raster*} object giving the spatial covariates
-#'  for the conditional part of the model
-#'
-#' @param extra_terms an optional formula object (of the form \code{~ s(x, k = 2)}
-#'  or similar which can be concatenated onto the model formula)
-#'  specifying further model components (in \code{extra_data}) not provided in
-#'  the spatial covariates.
-#'
-#' @param extra_data an optional dataframe giving the covariates referred to in
-#'  \code{extra_terms}
-#'
-#' @param bam whether to fit the model using \code{mgcv::bam} (the default),
-#'  otherwise \code{mgcv::gam} is used instead
-#'
+#'   
+#' @param condition an optional vector of 1s and 0s of the same length as the 
+#'   number of records in \code{coords} and \code{response} and stating whether 
+#'   the record should also be modelled using covariates in 
+#'   \code{condition_covs} (1 if so and 0 if not). This enables the construction
+#'   of slightly more complex models, such as those with an explicitly modelled 
+#'   observation process. This is achieved by passing \code{condition} to the 
+#'   \code{by} argument in \code{mgcv::s} when fitting smooths for the condition
+#'   covariates, as well as adding the condition as an intercept.
+#'   
+#' @param condition_covs an optional \code{Raster*} object giving the spatial 
+#'   covariates for the conditional part of the model
+#'   
+#' @param extra_terms an optional formula object (of the form \code{~ s(x, k = 
+#'   2)} or similar which can be concatenated onto the model formula) specifying
+#'   further model components (in \code{extra_data}) not provided in the spatial
+#'   covariates.
+#'   
+#' @param extra_data an optional dataframe giving the covariates referred to in 
+#'   \code{extra_terms}
+#'   
+#' @param bam whether to fit the model using \code{mgcv::bam} (the default), 
+#'   otherwise \code{mgcv::gam} is used instead
+#'   
 #' @param s_args a named list of additional arguments to pass to the smoother on
 #'   each covariate. For example, this may include the smoother type (\code{bs})
-#'   or the basis dimension (\code{k}). See \code{\link[mgcv]{s}} for the list
+#'   or the basis dimension (\code{k}). See \code{\link[mgcv]{s}} for the list 
 #'   of available arguments.
-#'
-#' @param predict whether to transform the rasters after fitting the model.
-#'  If set to \code{FALSE} this can enable model tweaking before the final
-#'  transformations are applied, without the computational cost of prediction
-#'
-#' @param \dots other arguments to be passed to \code{mgcv::bam} or
-#'  \code{mgcv::gam}
-#'
-#' @return a three-element named list containing:
-#'  \itemize{
-#'    \item{model}{the fitted \code{bam} or \code{gam} model object}
-#'    \item{trans}{if \code{predict = TRUE} a \code{Raster*} object of the
-#'     same extent, resolution and number of layers as \code{covs}, but with
-#'     the values of each layer having been optimally spline-transformed.
-#'     Otherwise \code{NULL}}
-#'    \item{trans_cond}{if \code{predict = TRUE} and \code{condition} is not
-#'     \code{NULL} a \code{Raster*} object of the same extent, resolution and
-#'     number of layers as \code{condition_covs}, but with the values of each layer
-#'     having been optimally spline-transformed. Otherwise \code{NULL}}
-#'  }
-#'
+#'   
+#' @param extract_args a named list of additional arguments to pass to 
+#'   \code{raster::}\code{\link[raster]{extract}}. For example, this may include
+#'   a buffer about the points from which to extract covariate values and the
+#'   function to aggregate these values.
+#'   
+#' @param predict whether to transform the rasters after fitting the model. If 
+#'   set to \code{FALSE} this can enable model tweaking before the final 
+#'   transformations are applied, without the computational cost of prediction
+#'   
+#' @param \dots other arguments to be passed to \code{mgcv::bam} or 
+#'   \code{mgcv::gam}
+#'   
+#' @return a three-element named list containing: \itemize{ \item{model}{the 
+#'   fitted \code{bam} or \code{gam} model object} \item{trans}{if \code{predict
+#'   = TRUE} a \code{Raster*} object of the same extent, resolution and number 
+#'   of layers as \code{covs}, but with the values of each layer having been 
+#'   optimally spline-transformed. Otherwise \code{NULL}} \item{trans_cond}{if 
+#'   \code{predict = TRUE} and \code{condition} is not \code{NULL} a 
+#'   \code{Raster*} object of the same extent, resolution and number of layers 
+#'   as \code{condition_covs}, but with the values of each layer having been 
+#'   optimally spline-transformed. Otherwise \code{NULL}} }
+#'   
 #' @export
 #' @import mgcv
 #' @import raster
-#'
+#'   
 gamTrans <- function(coords,
                      response,
                      covs,
@@ -141,6 +141,7 @@ gamTrans <- function(coords,
                      extra_data = NULL,
                      bam = TRUE,
                      s_args = list(),
+                     extract_args = list(),
                      predict = TRUE,
                      ...) {
 
@@ -205,8 +206,11 @@ gamTrans <- function(coords,
   # get training data
 
   # extract covariates
-  data <- data.frame(extract(covs, coords))
-
+  extract_args <- c(list(x = covs,
+                         y = coords),
+                    extract_args)
+  data <- data.frame(do.call(extract, extract_args))
+  
   # optionally combine this with the conditional and extra data
   if (cond)
     data <- cbind(data,

--- a/R/utility.R
+++ b/R/utility.R
@@ -248,7 +248,12 @@ rowProds <- function(x, na.rm = FALSE, dims = 1) {
 aggMatrix <- function(x, index, fun = sum, margin = 1, ...) {
   # aggregate rows of a matrix for dataframe using function and according to
   # index
-  agg <- function(x) tapply(x, INDEX = index, FUN = fun, ...)
+  agg <- function(x) {
+    res <- tapply(x, INDEX = index, FUN = fun, ...)
+    # reorder to match index's order
+    o <- match(index, names(res))
+    res[o]
+  }
   margin <- ifelse(margin == 1, 2, 1)
   apply(x, margin, agg)
 }

--- a/man/gamTrans.Rd
+++ b/man/gamTrans.Rd
@@ -6,75 +6,76 @@
 \usage{
 gamTrans(coords, response, covs, family = gaussian, condition = NULL,
   condition_covs = NULL, extra_terms = NULL, extra_data = NULL,
-  bam = TRUE, s_args = list(), predict = TRUE, ...)
+  bam = TRUE, s_args = list(), extract_args = list(), predict = TRUE,
+  ...)
 }
 \arguments{
 \item{coords}{a two-column matrix of coordinates of records}
 
-\item{response}{an object acting as thge response object in the GAM
-model (e.g. a vector of counts, or a matrix for binomial data)}
+\item{response}{an object acting as thge response object in the GAM model 
+(e.g. a vector of counts, or a matrix for binomial data)}
 
-\item{covs}{a \code{Raster*} object giving the spatial covariates
-for the main part of the model}
+\item{covs}{a \code{Raster*} object giving the spatial covariates for the 
+main part of the model}
 
 \item{family}{the distribution family for the gam}
 
-\item{condition}{an optional vector of 1s and 0s of the same length as
-the number of records in \code{coords} and \code{response} and stating
-whether the record should also be modelled using covariates in
+\item{condition}{an optional vector of 1s and 0s of the same length as the 
+number of records in \code{coords} and \code{response} and stating whether 
+the record should also be modelled using covariates in 
 \code{condition_covs} (1 if so and 0 if not). This enables the construction
-of slightly more complex models, such as those with an explicitly modelled
-observation process. This is achieved by passing \code{condition} to the
-\code{by} argument in \code{mgcv::s} when fitting smooths for
-the condition covariates, as well as adding the condition as an intercept.}
+of slightly more complex models, such as those with an explicitly modelled 
+observation process. This is achieved by passing \code{condition} to the 
+\code{by} argument in \code{mgcv::s} when fitting smooths for the condition
+covariates, as well as adding the condition as an intercept.}
 
-\item{condition_covs}{an optional \code{Raster*} object giving the spatial covariates
-for the conditional part of the model}
+\item{condition_covs}{an optional \code{Raster*} object giving the spatial 
+covariates for the conditional part of the model}
 
-\item{extra_terms}{an optional formula object (of the form \code{~ s(x, k = 2)}
-or similar which can be concatenated onto the model formula)
-specifying further model components (in \code{extra_data}) not provided in
-the spatial covariates.}
+\item{extra_terms}{an optional formula object (of the form \code{~ s(x, k = 
+2)} or similar which can be concatenated onto the model formula) specifying
+further model components (in \code{extra_data}) not provided in the spatial
+covariates.}
 
-\item{extra_data}{an optional dataframe giving the covariates referred to in
+\item{extra_data}{an optional dataframe giving the covariates referred to in 
 \code{extra_terms}}
 
-\item{bam}{whether to fit the model using \code{mgcv::bam} (the default),
+\item{bam}{whether to fit the model using \code{mgcv::bam} (the default), 
 otherwise \code{mgcv::gam} is used instead}
 
 \item{s_args}{a named list of additional arguments to pass to the smoother on
 each covariate. For example, this may include the smoother type (\code{bs})
-or the basis dimension (\code{k}). See \code{\link[mgcv]{s}} for the list
+or the basis dimension (\code{k}). See \code{\link[mgcv]{s}} for the list 
 of available arguments.}
 
-\item{predict}{whether to transform the rasters after fitting the model.
-If set to \code{FALSE} this can enable model tweaking before the final
+\item{extract_args}{a named list of additional arguments to pass to 
+\code{raster::}\code{\link[raster]{extract}}. For example, this may include
+a buffer about the points from which to extract covariate values and the
+function to aggregate these values.}
+
+\item{predict}{whether to transform the rasters after fitting the model. If 
+set to \code{FALSE} this can enable model tweaking before the final 
 transformations are applied, without the computational cost of prediction}
 
-\item{\dots}{other arguments to be passed to \code{mgcv::bam} or
+\item{\dots}{other arguments to be passed to \code{mgcv::bam} or 
 \code{mgcv::gam}}
 }
 \value{
-a three-element named list containing:
- \itemize{
-   \item{model}{the fitted \code{bam} or \code{gam} model object}
-   \item{trans}{if \code{predict = TRUE} a \code{Raster*} object of the
-    same extent, resolution and number of layers as \code{covs}, but with
-    the values of each layer having been optimally spline-transformed.
-    Otherwise \code{NULL}}
-   \item{trans_cond}{if \code{predict = TRUE} and \code{condition} is not
-    \code{NULL} a \code{Raster*} object of the same extent, resolution and
-    number of layers as \code{condition_covs}, but with the values of each layer
-    having been optimally spline-transformed. Otherwise \code{NULL}}
- }
+a three-element named list containing: \itemize{ \item{model}{the 
+  fitted \code{bam} or \code{gam} model object} \item{trans}{if \code{predict
+  = TRUE} a \code{Raster*} object of the same extent, resolution and number 
+  of layers as \code{covs}, but with the values of each layer having been 
+  optimally spline-transformed. Otherwise \code{NULL}} \item{trans_cond}{if 
+  \code{predict = TRUE} and \code{condition} is not \code{NULL} a 
+  \code{Raster*} object of the same extent, resolution and number of layers 
+  as \code{condition_covs}, but with the values of each layer having been 
+  optimally spline-transformed. Otherwise \code{NULL}} }
 }
 \description{
-Define an optimal set of univariate covariate
- transformations of a set of model covariates by fitting a generalised
- additive model with univariate smoothers to data, and then using the
- smoothers to spline-transform the covariates.
- This makes use of the\code{type = 'terms'} argument in
- \code{\link{predict.gam}}.
- This function also makes use of
+Define an optimal set of univariate covariate transformations of
+  a set of model covariates by fitting a generalised additive model with 
+  univariate smoothers to data, and then using the smoothers to 
+  spline-transform the covariates. This makes use of the\code{type = 'terms'}
+  argument in \code{\link{predict.gam}}. This function also makes use of
 }
 


### PR DESCRIPTION
Fixes a bug where the values calculated by `periodTabulate()` were sorted in ascending alphanumeric order of cluster ID, but the cluster ID columns weren't.
I.e. the results were being shuffled between clusters when the ID's weren't already in ascending order.